### PR TITLE
Introduce HTTPS transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Since it's compatible with the Logger interface, you can also use it in your Rai
 * Fork the project.
 * Make your feature addition or bug fix.
 * Add tests for it. This is important so I don't break it in a future version unintentionally.
+* Run the tests with `bundle exec rake` 
 * Commit, do not mess with rakefile, version, or history.
   (if you want to have your own version, that is fine but bump version in a commit by itself I can ignore when I pull)
 * Send me a pull request. Bonus points for topic branches.

--- a/lib/gelf.rb
+++ b/lib/gelf.rb
@@ -8,6 +8,7 @@ module GELF
   module Protocol
     UDP = 0
     TCP = 1
+    HTTPS = 2
   end
 end
 

--- a/lib/gelf/notifier.rb
+++ b/lib/gelf/notifier.rb
@@ -135,6 +135,8 @@ module GELF
   private
 
     def create_sender(host, port)
+      return create_https(host, port) if default_options['protocol'] == GELF::Protocol::HTTPS
+
       addresses = [[host, port]]
       if default_options['protocol'] == GELF::Protocol::TCP
         if default_options.key?('tls')
@@ -146,6 +148,10 @@ module GELF
       else
         GELF::Transport::UDP.new(addresses)
       end
+    end
+
+    def create_https(host, port)
+      GELF::Transport::HTTPS.new host, port: port, path: default_options.delete('path')
     end
 
     def notify_with_level(message_level, *args)
@@ -161,6 +167,8 @@ module GELF
       hash = extract_hash(*args)
       hash['level'] = message_level unless message_level.nil?
       if hash['level'] >= level
+        return @sender.transfer(hash) if default_options['protocol'] == GELF::Protocol::HTTPS
+
         if default_options['protocol'] == GELF::Protocol::TCP
           validate_hash(hash)
           @sender.send(hash.to_json + "\0")

--- a/lib/gelf/transport/https.rb
+++ b/lib/gelf/transport/https.rb
@@ -1,0 +1,26 @@
+module GELF
+  module Transport
+    class HTTPS
+      attr_reader :uri
+
+      def initialize(host, port: 443, path: nil)
+        path = "/#{path.to_s.delete_prefix('/')}" if path.present?
+        @uri = URI::HTTPS.build host: host, port: port, path: path
+      end
+
+      def transfer(message)
+        Typhoeus::Request.new(uri, method: :post,
+                                   headers: default_headers,
+                                   body: message.to_json).run
+      end
+
+      def default_headers
+        {
+          Accept: 'application/json',
+          'User-Agent' => Rails.application.class.name.deconstantize,
+          'Content-Type' => 'application/json'
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
UDP and TCP are great if the server is within the same secured
network.
TCP with TLS is working if one wants to deal with certificates
at the Graylog server.
HTTPS should be introduced as an option to send logs via the
internet in a encrypted way without necessarily setting up
TCP-TLS.