### PR TITLE
Fix requiring HTTPS in notifier

### DIFF
--- a/lib/gelf/notifier.rb
+++ b/lib/gelf/notifier.rb
@@ -1,6 +1,7 @@
 require 'gelf/transport/udp'
 require 'gelf/transport/tcp'
 require 'gelf/transport/tcp_tls'
+require 'gelf/transport/https'
 
 # replace JSON and #to_json with Yajl if available
 begin


### PR DESCRIPTION
The HTTPS transport file is expected to be
required in the notifier.